### PR TITLE
Fix session leak via SAML `RelayState`

### DIFF
--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.server.auth.saml.HtmlUtil.getHtmlWithOnload;
 import static java.util.Objects.requireNonNull;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -38,7 +40,6 @@ import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Response;
 
 import com.google.common.base.Strings;
-import com.google.common.html.HtmlEscapers;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
@@ -126,8 +127,12 @@ final class SamlAuthSsoHandler implements SamlSingleSignOnHandler {
 
         final String redirectionScript;
         if (!Strings.isNullOrEmpty(relayState)) {
-            redirectionScript = "window.location.href='/#" +
-                                HtmlEscapers.htmlEscaper().escape(relayState) + '\'';
+            try {
+                redirectionScript = "window.location.href='/#" + URLEncoder.encode(relayState, "UTF-8") + '\'';
+            } catch (UnsupportedEncodingException e) {
+                // Should never reach here.
+                throw new Error();
+            }
         } else {
             redirectionScript = "window.location.href='/'";
         }

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandlerTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandlerTest.java
@@ -65,6 +65,6 @@ class SamlAuthSsoHandlerTest {
                 samlAuthSsoHandler.loginSucceeded(ctx, req, messageContext, null, relayState);
         assertThat(httpResponse.aggregate().join().contentUtf8()).isEqualTo(getHtmlWithOnload(
                 "localStorage.setItem('sessionId','id')",
-                "window.location.href='/#&#39;.substr(0.1)&#39;&quot;&amp;&lt;&gt;'"));
+                "window.location.href='/#%27.substr%280.1%29%27%22%26%3C%3E'"));
     }
 }


### PR DESCRIPTION
Motivation:
This is a follow-up for https://github.com/line/centraldogma/commit/8edcf913b88101aff70008156b0881850e005783 The `RelayState` must be url encoded instead of HTML escaping because it's used in the URL. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-url-contexts

Modification:
- URL-encode `RelayState` Result:
- Improved security by mitigating the risk of XSS attacks through URL encoding of SAML `RelayState`.